### PR TITLE
add link to 'Equality in tech' article back in

### DIFF
--- a/src/_data/links/qmacro.json
+++ b/src/_data/links/qmacro.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://qmacro.org/blog/posts/2021/05/20/equality-in-tech/",
+  "title": "Equality in tech",
+  "author": "DJ Adams",
+  "excerpt": "I support equality in tech, and so should you.",
+  "githubUsername": "qmacro"
+}


### PR DESCRIPTION
Helloooo! The article that I contributed in the early days of unbreak.tech changed URLs (my bad) and so was excluded due to a 404 being returned from it when the site was rebuilt. This PR puts it back. Thanks! 