### PR TITLE
Fix top level domain in article url

### DIFF
--- a/src/_data/links/kevinmcdonnell.json
+++ b/src/_data/links/kevinmcdonnell.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.mcd79.dev/2021/07/09/toxic-male-behaviour-we-can-and-must-do-better",
+  "url": "https://www.mcd79.com/2021/07/09/toxic-male-behaviour-we-can-and-must-do-better",
   "title": "Toxic male behaviour - we can and must do better",
   "author": "Kevin McDonnell",
   "excerpt": "I think I have made assumptions about someone's role based on their sex. I hate myself for this and I try and learn.",


### PR DESCRIPTION
When I clicked on 'Read article' for Kevin McDonnell's article "Toxic male behaviour - we can and must do better", I got "This site can’t be reached".

I googled the article name directly and noticed that the top level domain of the url was incorrect -- `.dev` should be `.com`

This PR updates the top level domain of the url to be the correct one :)